### PR TITLE
Aquamarket parser

### DIFF
--- a/cmd/parser/main.go
+++ b/cmd/parser/main.go
@@ -3,12 +3,12 @@ package main
 import (
 	"encoding/json"
 	"flag"
-	"fmt"
 	"github.com/quercus-insolita/hircum-triticum/internal/parsing"
 	log "github.com/sirupsen/logrus"
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 )
 
 func main() {
@@ -25,27 +25,30 @@ func main() {
 	name := flag.String(
 		"parser",
 		names[0],
-		fmt.Sprintf("Underlying data source, one of %v", names),
+		"Underlying data source, one of \""+strings.Join(names, "\", \"")+"\"",
 	)
 	port := flag.Int("port", 9427, "Application's HTTP server port")
+	isLog := flag.Bool("log", false, "Should the app output logs to a file")
 	flag.Parse()
 	parser, ok := parsers[*name]
 	if !ok {
 		log.Fatalf("main: failed to find parser %s among %v", *name, names)
 	}
-	file, err := os.OpenFile(
-		"logs/parser-"+*name+".log",
-		os.O_WRONLY|os.O_CREATE|os.O_APPEND,
-		0644,
-	)
-	if err != nil {
-		log.Fatalf("main: failed to open a log file, %v", err)
+	if *isLog {
+		file, err := os.OpenFile(
+			"logs/parser-"+*name+".log",
+			os.O_WRONLY|os.O_CREATE|os.O_APPEND,
+			0644,
+		)
+		if err != nil {
+			log.Fatalf("main: failed to open a log file, %v", err)
+		}
+		defer func() {
+			_ = file.Close()
+		}()
+		log.SetOutput(file)
 	}
-	defer func() {
-		_ = file.Close()
-	}()
-	log.SetOutput(file)
-	if err = http.ListenAndServe(":"+strconv.Itoa(*port), handle(parser)); err != nil {
+	if err := http.ListenAndServe(":"+strconv.Itoa(*port), handle(parser)); err != nil {
 		log.Fatalf("main: failed to start server, %v", err)
 	}
 }

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,20 +1,34 @@
 version: '3.8'
+x-parser: &x-parser
+  image: hircum-triticum-parser
+  entrypoint: go run github.com/quercus-insolita/hircum-triticum/cmd/parser
+  volumes:
+    - ./go.mod:/go/src/app/go.mod
+    - ./go.sum:/go/src/app/go.sum
+    - ./cmd:/go/src/app/cmd
+    - ./internal:/go/src/app/internal
+    - ./logs:/go/src/app/logs
 services:
   parser:
+    <<: *x-parser
     build:
       context: .
       dockerfile: docker/dev/parser.dockerfile
-    image: hircum-triticum-parser
     container_name: hircum-triticum-parser
-    command: go run github.com/quercus-insolita/hircum-triticum/cmd/parser
     ports:
       - 9427:9427
-    volumes:
-      - ./go.mod:/go/src/app/go.mod
-      - ./go.sum:/go/src/app/go.sum
-      - ./cmd:/go/src/app/cmd
-      - ./internal:/go/src/app/internal
-      - ./logs:/go/src/app/logs
+  parser-auchan:
+    <<: *x-parser
+    container_name: hircum-triticum-parser-auchan
+    command: -parser auchan -port 9428
+    ports:
+      - 9428:9428
+  parser-aquamarket:
+    <<: *x-parser
+    container_name: hircum-triticum-parser-aquamarket
+    command: -parser aquamarket -port 9429
+    ports:
+      - 9429:9429
 networks:
   default:
     name: hircum-triticum-default

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -15,6 +15,7 @@ services:
       context: .
       dockerfile: docker/dev/parser.dockerfile
     container_name: hircum-triticum-parser
+    command: -parser aquamarket
     ports:
       - 9427:9427
   parser-auchan:

--- a/docker-compose-prd.yml
+++ b/docker-compose-prd.yml
@@ -1,16 +1,26 @@
 version: '3.8'
+x-parser: &x-parser
+  image: hircum-triticum-parser
+  volumes:
+    - ./logs:/logs
 services:
   parser:
     build:
       context: .
       dockerfile: docker/prd/parser.dockerfile
     image: hircum-triticum-parser
-    container_name: hircum-triticum-parser
-    command: -port 29115
+  parser-auchan:
+    <<: *x-parser
+    container_name: hircum-triticum-parser-auchan
+    command: -parser auchan -port 29116 -log
     ports:
-      - 29115:29115
-    volumes:
-      - ./logs:/logs
+      - 29116:29116
+  parser-aquamarket:
+    <<: *x-parser
+    container_name: hircum-triticum-parser-aquamarket
+    command: -parser aquamarket -port 29117 -log
+    ports:
+      - 29117:29117
 networks:
   default:
     name: hircum-triticum-default

--- a/docker/prd/parser.dockerfile
+++ b/docker/prd/parser.dockerfile
@@ -15,7 +15,7 @@ RUN adduser -D -g "" parser && \
     rm -rf /var/cache/apk/* && \
     rm -rf /tmp/* && \
     apk update && \
-    apk add --no-cache git ca-certificates && \
+    apk add --no-cache git=2.30.0-r0 ca-certificates=20161130-r0 && \
     update-ca-certificates && \
     go get ./... && \
     mkdir -p bin && \

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,5 @@ go 1.15
 require (
 	github.com/PuerkitoBio/goquery v1.6.1
 	github.com/sirupsen/logrus v1.7.0
-	golang.org/x/net v0.0.0-20200202094626-16171245cfb2
 	golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 // indirect
 )

--- a/internal/parsing/aquamarket_parser.go
+++ b/internal/parsing/aquamarket_parser.go
@@ -1,0 +1,20 @@
+package parsing
+
+import (
+	log "github.com/sirupsen/logrus"
+	"net/http"
+	"time"
+)
+
+func MewAquamarketParser(logger log.FieldLogger) Parser {
+	return &aquamarketParser{&http.Client{Timeout: time.Second * 10}, logger}
+}
+
+type aquamarketParser struct {
+	client *http.Client
+	logger log.FieldLogger
+}
+
+func (p *aquamarketParser) ParseBuckwheats() ([]Buckwheat, error) {
+	return make([]Buckwheat, 0), nil
+}

--- a/internal/parsing/aquamarket_parser.go
+++ b/internal/parsing/aquamarket_parser.go
@@ -5,15 +5,21 @@ import (
 	"github.com/PuerkitoBio/goquery"
 	log "github.com/sirupsen/logrus"
 	"net/http"
+	"regexp"
+	"strconv"
 	"time"
 )
 
 func MewAquamarketParser() Parser {
-	return &aquamarketParser{&helper{&http.Client{Timeout: time.Second * 10}}}
+	return &aquamarketParser{
+		&helper{&http.Client{Timeout: time.Second * 10}},
+		regexp.MustCompile(`^.*, (\d+ \* )?(\d+) (к?г)(\W.*)?$`),
+	}
 }
 
 type aquamarketParser struct {
 	helper *helper
+	regexp *regexp.Regexp
 }
 
 func (p *aquamarketParser) ParseBuckwheats() ([]Buckwheat, error) {
@@ -52,9 +58,51 @@ func (p *aquamarketParser) parseBuckwheat(selection *goquery.Selection) (Buckwhe
 	if buckwheat.URL == "" {
 		return buckwheat, fmt.Errorf("parsing: parser found no url")
 	}
-	buckwheat.URL = "https://aquamarket.ua" + buckwheat.URL
 	if buckwheat.Title == "" {
 		return buckwheat, fmt.Errorf("parsing: parser found no title")
 	}
-	return buckwheat, nil
+	nodes = selection.Find("span.price.product-price[content]").Nodes
+	if len(nodes) != 1 {
+		return buckwheat, fmt.Errorf("parsing: parser found no price node")
+	}
+	var price string
+	for _, attribute := range nodes[0].Attr {
+		if attribute.Key == "content" {
+			price = attribute.Val
+		}
+	}
+	buckwheat.Price, err = strconv.ParseFloat(price, 64)
+	if err != nil {
+		return buckwheat, fmt.Errorf("parsing: parser failed to parse price, %v", err)
+	}
+	if buckwheat.Price <= 0 {
+		return buckwheat, fmt.Errorf("parsing: parser found non-positive price")
+	}
+	groups := p.regexp.FindStringSubmatch(buckwheat.Title)
+	buckwheat.Mass, err = strconv.ParseFloat(groups[2], 64)
+	if err != nil {
+		return buckwheat, fmt.Errorf("parsing: parser failed to parse right mass, %v", err)
+	}
+	if buckwheat.Mass <= 0 {
+		return buckwheat, fmt.Errorf("parsing: parser found non-positive right mass")
+	}
+	if groups[1] != "" {
+		mass, err := strconv.ParseFloat(groups[1][:len(groups[1])-3], 64)
+		if err != nil {
+			return buckwheat, fmt.Errorf("parsing: parser failed to parse left mass, %v", err)
+		}
+		if mass <= 0 {
+			return buckwheat, fmt.Errorf("parsing: parser found non-positive left mass")
+		}
+		buckwheat.Mass *= mass
+	}
+	switch groups[3] {
+	case "кг":
+		return buckwheat, nil
+	case "г":
+		buckwheat.Mass /= 1000
+		return buckwheat, nil
+	default:
+		return buckwheat, fmt.Errorf("parsing: parser found unknown mass unit")
+	}
 }

--- a/internal/parsing/aquamarket_parser.go
+++ b/internal/parsing/aquamarket_parser.go
@@ -1,18 +1,36 @@
 package parsing
 
 import (
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/net/html"
 	"net/http"
 	"time"
 )
 
 func MewAquamarketParser() Parser {
-	return &aquamarketParser{&http.Client{Timeout: time.Second * 10}}
+	return &aquamarketParser{&helper{&http.Client{Timeout: time.Second * 10}}}
 }
 
 type aquamarketParser struct {
-	client *http.Client
+	helper *helper
 }
 
 func (p *aquamarketParser) ParseBuckwheats() ([]Buckwheat, error) {
-	return make([]Buckwheat, 0), nil
+	document, err := p.helper.readDocument("https://aquamarket.ua/uk/1099-grechka")
+	if err != nil {
+		return nil, err
+	}
+	buckwheats := make([]Buckwheat, 0)
+	for _, node := range document.Find("div.product:not(.product-not-available)").Nodes {
+		if buckwheat, err := p.parseBuckwheat(node); err != nil {
+			log.WithField("url", buckwheat.URL).Error(err)
+		} else {
+			buckwheats = append(buckwheats, buckwheat)
+		}
+	}
+	return buckwheats, nil
+}
+
+func (p *aquamarketParser) parseBuckwheat(node *html.Node) (Buckwheat, error) {
+	return Buckwheat{}, nil
 }

--- a/internal/parsing/aquamarket_parser.go
+++ b/internal/parsing/aquamarket_parser.go
@@ -1,18 +1,16 @@
 package parsing
 
 import (
-	log "github.com/sirupsen/logrus"
 	"net/http"
 	"time"
 )
 
-func MewAquamarketParser(logger log.FieldLogger) Parser {
-	return &aquamarketParser{&http.Client{Timeout: time.Second * 10}, logger}
+func MewAquamarketParser() Parser {
+	return &aquamarketParser{&http.Client{Timeout: time.Second * 10}}
 }
 
 type aquamarketParser struct {
 	client *http.Client
-	logger log.FieldLogger
 }
 
 func (p *aquamarketParser) ParseBuckwheats() ([]Buckwheat, error) {

--- a/internal/parsing/auchan_parser.go
+++ b/internal/parsing/auchan_parser.go
@@ -11,13 +11,12 @@ import (
 	"time"
 )
 
-func NewAuchanHandler(logger log.FieldLogger) Parser {
-	return &auchanParser{&http.Client{Timeout: time.Second * 10}, logger}
+func NewAuchanHandler() Parser {
+	return &auchanParser{&http.Client{Timeout: time.Second * 10}}
 }
 
 type auchanParser struct {
 	client *http.Client
-	logger log.FieldLogger
 }
 
 func (p *auchanParser) ParseBuckwheats() ([]Buckwheat, error) {
@@ -48,7 +47,7 @@ func (p *auchanParser) ParseBuckwheats() ([]Buckwheat, error) {
 	buckwheats := make([]Buckwheat, 0)
 	for _, node := range document.Find("a.product-tile").Nodes {
 		if buckwheat, err := p.parseBuckwheat(node); err != nil {
-			p.logger.WithField("url", buckwheat.URL).Error(err)
+			log.WithField("url", buckwheat.URL).Error(err)
 		} else {
 			buckwheats = append(buckwheats, buckwheat)
 		}

--- a/internal/parsing/auchan_parser.go
+++ b/internal/parsing/auchan_parser.go
@@ -11,7 +11,7 @@ import (
 	"time"
 )
 
-func NewAuchanHandler() Parser {
+func NewAuchanParser() Parser {
 	return &auchanParser{&http.Client{Timeout: time.Second * 10}}
 }
 

--- a/internal/parsing/auchan_parser.go
+++ b/internal/parsing/auchan_parser.go
@@ -12,37 +12,19 @@ import (
 )
 
 func NewAuchanParser() Parser {
-	return &auchanParser{&http.Client{Timeout: time.Second * 10}}
+	return &auchanParser{&helper{&http.Client{Timeout: time.Second * 10}}}
 }
 
 type auchanParser struct {
-	client *http.Client
+	helper *helper
 }
 
 func (p *auchanParser) ParseBuckwheats() ([]Buckwheat, error) {
-	request, err := http.NewRequest(
-		http.MethodGet,
+	document, err := p.helper.readDocument(
 		"https://auchan.zakaz.ua/uk/categories/buckwheat-auchan/",
-		nil,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("parsing: parser failed to make a request, %v", err)
-	}
-	response, err := p.client.Do(request)
-	if err != nil {
-		return nil, fmt.Errorf("parsing: parser failed to send a request, %v", err)
-	}
-	if response.StatusCode != http.StatusOK {
-		_ = response.Body.Close()
-		return nil, fmt.Errorf("parsing: parser failed with status %s", response.Status)
-	}
-	document, err := goquery.NewDocumentFromReader(response.Body)
-	if err != nil {
-		_ = response.Body.Close()
-		return nil, fmt.Errorf("parsing: parser failed to read a document, %v", err)
-	}
-	if err := response.Body.Close(); err != nil {
-		return nil, fmt.Errorf("parsing: parser failed to close a response body, %v", err)
+		return nil, err
 	}
 	buckwheats := make([]Buckwheat, 0)
 	for _, node := range document.Find("a.product-tile").Nodes {

--- a/internal/parsing/helper.go
+++ b/internal/parsing/helper.go
@@ -1,0 +1,35 @@
+package parsing
+
+import (
+	"fmt"
+	"github.com/PuerkitoBio/goquery"
+	"net/http"
+)
+
+type helper struct {
+	client *http.Client
+}
+
+func (h *helper) parseDocument(url string) (*goquery.Document, error) {
+	request, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("parsing: helper failed to make a request, %v", err)
+	}
+	response, err := h.client.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("parsing: helper failed to send a request, %v", err)
+	}
+	if response.StatusCode != http.StatusOK {
+		_ = response.Body.Close()
+		return nil, fmt.Errorf("parsing: helper failed with status %s", response.Status)
+	}
+	document, err := goquery.NewDocumentFromReader(response.Body)
+	if err != nil {
+		_ = response.Body.Close()
+		return nil, fmt.Errorf("parsing: helper failed to read a document, %v", err)
+	}
+	if err := response.Body.Close(); err != nil {
+		return nil, fmt.Errorf("parsing: helper failed to close a response body, %v", err)
+	}
+	return document, nil
+}

--- a/internal/parsing/helper.go
+++ b/internal/parsing/helper.go
@@ -10,7 +10,7 @@ type helper struct {
 	client *http.Client
 }
 
-func (h *helper) parseDocument(url string) (*goquery.Document, error) {
+func (h *helper) readDocument(url string) (*goquery.Document, error) {
 	request, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("parsing: helper failed to make a request, %v", err)

--- a/lets.yaml
+++ b/lets.yaml
@@ -2,10 +2,13 @@ shell: bash
 commands:
   build:
     description: Compiles all docker images for local development
-    cmd: docker-compose -f docker-compose-dev.yml build parser
+    cmd: mkdir -p logs && docker-compose -f docker-compose-dev.yml build parser
   parser:
     description: Up site parser service
-    cmd: mkdir -p logs && docker-compose -f docker-compose-dev.yml up -d parser
+    cmd: docker-compose -f docker-compose-dev.yml up -d parser
+  run:
+    description: Activate the whole service ecosystem
+    cmd: docker-compose -f docker-compose-dev.yml up -d parser-auchan parser-aquamarket
   stop:
     description: Dispose all docker stuff
     cmd: docker-compose -f docker-compose-dev.yml down

--- a/lets.yaml
+++ b/lets.yaml
@@ -11,5 +11,5 @@ commands:
   run:
     description: Activate the whole service ecosystem
     cmd: |
-      docker-compose -f docker-compose-dev.yml upparser-auchan parser-aquamarket
+      docker-compose -f docker-compose-dev.yml up parser-auchan parser-aquamarket
       docker-compose -f docker-compose-dev.yml down

--- a/lets.yaml
+++ b/lets.yaml
@@ -5,7 +5,7 @@ commands:
     cmd: mkdir -p logs && docker-compose -f docker-compose-dev.yml build parser
   parser:
     description: Up site parser service
-    cmd: docker-compose -f docker-compose-dev.yml up -d parser
+    cmd: docker-compose -f docker-compose-dev.yml up parser
   run:
     description: Activate the whole service ecosystem
     cmd: docker-compose -f docker-compose-dev.yml up -d parser-auchan parser-aquamarket

--- a/lets.yaml
+++ b/lets.yaml
@@ -5,10 +5,11 @@ commands:
     cmd: mkdir -p logs && docker-compose -f docker-compose-dev.yml build parser
   parser:
     description: Up site parser service
-    cmd: docker-compose -f docker-compose-dev.yml up parser
+    cmd: |
+      docker-compose -f docker-compose-dev.yml up parser
+      docker-compose -f docker-compose-dev.yml down
   run:
     description: Activate the whole service ecosystem
-    cmd: docker-compose -f docker-compose-dev.yml up -d parser-auchan parser-aquamarket
-  stop:
-    description: Dispose all docker stuff
-    cmd: docker-compose -f docker-compose-dev.yml down
+    cmd: |
+      docker-compose -f docker-compose-dev.yml upparser-auchan parser-aquamarket
+      docker-compose -f docker-compose-dev.yml down

--- a/scripts/workflow.sh
+++ b/scripts/workflow.sh
@@ -1,5 +1,5 @@
 mkdir -p logs && \
 docker-compose -f docker-compose-prd.yml build --no-cache parser && \
 docker-compose -f docker-compose-prd.yml down && \
-docker-compose -f docker-compose-prd.yml up -d parser && \
+docker-compose -f docker-compose-prd.yml up -d parser-auchan parser-aquamarket && \
 docker image prune -f


### PR DESCRIPTION
Додав парсинг і підтримку [aquamarket.ua](https://aquamarket.ua/). Тепер у `auchan` є альтернатива. До консольних аргументів парсера додано `-parser` для вказівки імені парсера й `-log` - прапор логування до stdout чи файлу.